### PR TITLE
tests: add 192 unit tests for tools, agent, MCP, browser, and web UI modules

### DIFF
--- a/tests/test_browse_function.py
+++ b/tests/test_browse_function.py
@@ -1,0 +1,180 @@
+"""Tests for the browse() convenience function and _resolve_model_and_provider in browser.py."""
+
+import queue
+from unittest.mock import MagicMock, patch
+
+from browsegenie.browser import _resolve_model_and_provider, browse
+
+
+# ── _resolve_model_and_provider ───────────────────────────────────────────────
+
+class TestResolveModelAndProvider:
+    """Tests for the provider auto-detection helper."""
+
+    def test_explicit_provider_passthrough(self):
+        """Test that an explicitly supplied provider is returned unchanged."""
+        model, prov = _resolve_model_and_provider("my-model", "mycloud")
+        assert prov == "mycloud"
+        assert model == "my-model"
+
+    def test_gpt_prefix_detects_openai(self):
+        """Test that a model starting with 'gpt-' is identified as openai."""
+        _, prov = _resolve_model_and_provider("gpt-4o", None)
+        assert prov == "openai"
+
+    def test_o1_prefix_detects_openai(self):
+        """Test that a model starting with 'o1' is identified as openai."""
+        _, prov = _resolve_model_and_provider("o1-mini", None)
+        assert prov == "openai"
+
+    def test_o3_prefix_detects_openai(self):
+        """Test that a model starting with 'o3' is identified as openai."""
+        _, prov = _resolve_model_and_provider("o3-mini", None)
+        assert prov == "openai"
+
+    def test_o4_prefix_detects_openai(self):
+        """Test that a model starting with 'o4' is identified as openai."""
+        _, prov = _resolve_model_and_provider("o4-mini", None)
+        assert prov == "openai"
+
+    def test_claude_prefix_detects_anthropic(self):
+        """Test that a model starting with 'claude-' is identified as anthropic."""
+        _, prov = _resolve_model_and_provider("claude-3-5-sonnet-20241022", None)
+        assert prov == "anthropic"
+
+    def test_gemini_prefix_detects_google(self):
+        """Test that a model starting with 'gemini-' is identified as google."""
+        _, prov = _resolve_model_and_provider("gemini-2.5-flash", None)
+        assert prov == "google"
+
+    def test_mistral_prefix_detects_mistral(self):
+        """Test that a model starting with 'mistral' is identified as mistral."""
+        _, prov = _resolve_model_and_provider("mistral-7b", None)
+        assert prov == "mistral"
+
+    def test_deepseek_prefix_detects_deepseek(self):
+        """Test that a model starting with 'deepseek' is identified as deepseek."""
+        _, prov = _resolve_model_and_provider("deepseek-chat", None)
+        assert prov == "deepseek"
+
+    def test_ollama_prefix_detects_ollama(self):
+        """Test that a model starting with 'ollama/' is identified as ollama."""
+        _, prov = _resolve_model_and_provider("ollama/llama3", None)
+        assert prov == "ollama"
+
+    def test_command_prefix_detects_cohere(self):
+        """Test that a model starting with 'command' is identified as cohere."""
+        _, prov = _resolve_model_and_provider("command-r", None)
+        assert prov == "cohere"
+
+    def test_grok_prefix_detects_xai(self):
+        """Test that a model starting with 'grok' is identified as xai."""
+        _, prov = _resolve_model_and_provider("grok-2", None)
+        assert prov == "xai"
+
+    def test_unknown_model_defaults_to_google(self):
+        """Test that an unrecognised model name defaults to the google provider."""
+        _, prov = _resolve_model_and_provider("some-random-model", None)
+        assert prov == "google"
+
+
+# ── browse() ──────────────────────────────────────────────────────────────────
+
+def _make_session(events=None):
+    """Return a mock BrowserAgentSession whose event_queue is pre-populated with events."""
+    session = MagicMock()
+    q = queue.Queue()
+    for ev in (events or []):
+        q.put(ev)
+    session.event_queue = q
+    session.get_playback_frames.return_value = []
+    type(session).is_done = property(lambda s: s.event_queue.empty())
+    return session
+
+
+class TestBrowseFunction:
+    """Tests for the top-level browse() convenience function."""
+
+    def _session_with_done_event(self):
+        """Return a session that emits a single done event."""
+        events = [{"type": "done", "data": {"summary": "Task complete", "data": {"k": "v"}}}]
+        return _make_session(events=events)
+
+    def test_browse_happy_path_returns_result_dict(self):
+        """Test that browse() returns a dict with all expected keys on success."""
+        session = self._session_with_done_event()
+        with patch("browsegenie.browser.create_session", return_value=session):
+            result = browse(
+                task="test task",
+                api_key="key",
+                model_name="gpt-4o",
+                show_logs=False,
+            )
+        assert result["success"] is True
+        assert result["summary"] == "Task complete"
+        assert result["data"] == {"k": "v"}
+
+    def test_browse_on_event_callback_fired(self):
+        """Test that on_event callback is called for each event when supplied."""
+        events = [
+            {"type": "step", "data": {"step": 1}},
+            {"type": "done", "data": {"summary": "done"}},
+        ]
+        session = _make_session(events=events)
+        captured = []
+        with patch("browsegenie.browser.create_session", return_value=session):
+            browse(
+                task="task",
+                api_key="k",
+                model_name="gpt-4o",
+                on_event=lambda t, _d: captured.append(t),
+                show_logs=False,
+            )
+        assert "step" in captured
+        assert "done" in captured
+
+    def test_browse_timeout_calls_stop(self):
+        """Test that browse() calls session.stop() when the timeout expires."""
+        session = _make_session(events=[])
+        # Make is_done always False so the timeout fires
+        type(session).is_done = property(lambda s: False)  # noqa: ARG005
+        with patch("browsegenie.browser.create_session", return_value=session):
+            result = browse(
+                task="task",
+                api_key="k",
+                model_name="gpt-4o",
+                timeout=0.05,
+                show_logs=False,
+            )
+        session.stop.assert_called()
+        assert result["error"] is not None
+
+    def test_browse_error_event_sets_error_key(self):
+        """Test that an error event sets result['error'] to the event message."""
+        events = [{"type": "error", "data": {"message": "Something went wrong"}}]
+        session = _make_session(events=events)
+        with patch("browsegenie.browser.create_session", return_value=session):
+            result = browse(
+                task="task",
+                api_key="k",
+                model_name="gpt-4o",
+                show_logs=False,
+            )
+        assert result["error"] == "Something went wrong"
+        assert result["success"] is False
+
+    def test_browse_step_event_updates_steps(self):
+        """Test that step events increment the steps counter in the result."""
+        events = [
+            {"type": "step", "data": {"step": 3}},
+            {"type": "done", "data": {"summary": "ok"}},
+        ]
+        session = _make_session(events=events)
+        with patch("browsegenie.browser.create_session", return_value=session):
+            result = browse(
+                task="task",
+                api_key="k",
+                model_name="gpt-4o",
+                show_logs=False,
+            )
+        assert result["steps"] == 3

--- a/tests/test_browser_session_module.py
+++ b/tests/test_browser_session_module.py
@@ -1,0 +1,123 @@
+"""Tests for BrowserAgentSession and module-level session registry in sessions.py."""
+
+import queue
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.agent.sessions import (
+    BrowserAgentSession,
+    get_session,
+)
+import browsegenie.core.browser_agent.agent.sessions as _sessions_module
+
+
+def _make_agent(should_raise=False):
+    """Return a mock BrowserAgent that finishes instantly (optionally raising)."""
+    agent = MagicMock()
+    agent.event_queue = queue.Queue()
+    agent.recorder = MagicMock()
+    agent.recorder.to_list.return_value = []
+    agent.control = MagicMock()
+    agent.control.mode = "shared"
+    if should_raise:
+        agent.run.side_effect = Exception("agent crash")
+    else:
+        agent.run.return_value = None
+    return agent
+
+
+class TestBrowserAgentSession:
+    """Tests for BrowserAgentSession lifecycle and delegation methods."""
+
+    def test_start_executes_agent_run(self):
+        """Test that start() calls agent.run() in a daemon thread and signals done."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        session.start()
+        session.done.wait(timeout=2.0)
+        agent.run.assert_called_once()
+
+    def test_is_done_after_run_completes(self):
+        """Test that is_done returns True after the agent thread finishes successfully."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        session.start()
+        session.done.wait(timeout=2.0)
+        assert session.is_done is True
+
+    def test_is_done_after_agent_exception(self):
+        """Test that is_done is True even when agent.run() raises an exception."""
+        agent = _make_agent(should_raise=True)
+        session = BrowserAgentSession(agent)
+        session.start()
+        session.done.wait(timeout=2.0)
+        assert session.is_done is True
+
+    def test_stop_calls_agent_stop_and_marks_done(self):
+        """Test that stop() calls agent.stop() and sets the done event."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        session.stop()
+        agent.stop.assert_called_once()
+        assert session.is_done is True
+
+    def test_get_playback_frames_delegates_to_recorder(self):
+        """Test that get_playback_frames() returns the list from agent.recorder.to_list()."""
+        agent = _make_agent()
+        agent.recorder.to_list.return_value = [{"index": 0}]
+        session = BrowserAgentSession(agent)
+        assert session.get_playback_frames() == [{"index": 0}]
+
+    def test_event_queue_property_returns_agent_queue(self):
+        """Test that the event_queue property proxies directly to the agent's queue."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        assert session.event_queue is agent.event_queue
+
+    def test_execute_control_delegates_to_control_layer(self):
+        """Test that execute_control passes action and payload to agent.control.enqueue_human."""
+        agent = _make_agent()
+        agent.control.enqueue_human.return_value = {"status": "queued"}
+        session = BrowserAgentSession(agent)
+        result = session.execute_control("click", {"x": 10})
+        agent.control.enqueue_human.assert_called_once_with("click", {"x": 10})
+        assert result["status"] == "queued"
+
+    def test_get_mode_delegates_to_control_mode(self):
+        """Test that get_mode() returns the control layer's mode attribute."""
+        agent = _make_agent()
+        agent.control.mode = "agent_only"
+        session = BrowserAgentSession(agent)
+        assert session.get_mode() == "agent_only"
+
+    def test_set_mode_delegates_to_control_set_mode(self):
+        """Test that set_mode() calls agent.control.set_mode with the given mode string."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        session.set_mode("human_only")
+        agent.control.set_mode.assert_called_once_with("human_only")
+
+    def test_session_id_is_unique(self):
+        """Test that two BrowserAgentSession instances receive different session IDs."""
+        a = BrowserAgentSession(_make_agent())
+        b = BrowserAgentSession(_make_agent())
+        assert a.session_id != b.session_id
+
+
+class TestSessionRegistry:
+    """Tests for the module-level create_session / get_session registry."""
+
+    def setup_method(self):
+        """Clear the global _sessions dict before each test to prevent cross-test pollution."""
+        _sessions_module._sessions.clear()
+
+    def test_get_session_missing_returns_none(self):
+        """Test that get_session returns None for an unregistered session ID."""
+        assert get_session("nonexistent-id") is None
+
+    def test_get_session_after_manual_insert(self):
+        """Test that a session manually added to _sessions is retrievable by its ID."""
+        agent = _make_agent()
+        session = BrowserAgentSession(agent)
+        _sessions_module._sessions[session.session_id] = session
+        assert get_session(session.session_id) is session

--- a/tests/test_html_fetcher_extra.py
+++ b/tests/test_html_fetcher_extra.py
@@ -1,0 +1,130 @@
+"""Extra tests for HtmlFetcher: SPA path, short-content fallback, dual-failure, selenium errors."""
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from browsegenie.core.html_fetcher import HtmlFetcher
+
+
+def _fetcher():
+    """Return an HtmlFetcher using an isolated temp directory."""
+    return HtmlFetcher(temp_dir=tempfile.mkdtemp())
+
+
+class TestFetchWithCloudscraper:
+    """Tests for fetch_with_cloudscraper() behaviour."""
+
+    def test_happy_path_returns_html(self):
+        """Test that fetch_with_cloudscraper returns the response text on success."""
+        fetcher = _fetcher()
+        mock_resp = MagicMock()
+        mock_resp.text = "<html><body>Hello</body></html>"
+        with patch("browsegenie.core.html_fetcher.cloudscraper.create_scraper") as mock_cs:
+            mock_cs.return_value.get.return_value = mock_resp
+            result = fetcher.fetch_with_cloudscraper("https://example.com")
+        assert result == "<html><body>Hello</body></html>"
+
+    def test_exception_returns_none(self):
+        """Test that fetch_with_cloudscraper returns None when the request raises an exception."""
+        fetcher = _fetcher()
+        with patch("browsegenie.core.html_fetcher.cloudscraper.create_scraper") as mock_cs:
+            mock_cs.return_value.get.side_effect = Exception("connection refused")
+            result = fetcher.fetch_with_cloudscraper("https://example.com")
+        assert result is None
+
+
+class TestFetchWithSelenium:
+    """Tests for fetch_with_selenium() error paths."""
+
+    def _chrome_patch(self, driver=None, exception=None):
+        """Return a context manager that patches webdriver.Chrome."""
+        if exception:
+            return patch(
+                "browsegenie.core.html_fetcher.webdriver.Chrome",
+                side_effect=exception,
+            )
+        mock_driver = driver or MagicMock()
+        return patch(
+            "browsegenie.core.html_fetcher.webdriver.Chrome",
+            return_value=mock_driver,
+        )
+
+    def test_timeout_exception_returns_none(self):
+        """Test that a Selenium TimeoutException causes fetch_with_selenium to return None."""
+        from selenium.common.exceptions import TimeoutException
+        fetcher = _fetcher()
+        mock_driver = MagicMock()
+        mock_driver.get.return_value = None
+        mock_wait = MagicMock()
+        mock_wait.until.side_effect = TimeoutException("timed out")
+        with self._chrome_patch(driver=mock_driver), \
+             patch("browsegenie.core.html_fetcher.WebDriverWait", return_value=mock_wait), \
+             patch("browsegenie.core.html_fetcher.time.sleep"):
+            result = fetcher.fetch_with_selenium("https://slow.example.com")
+        assert result is None
+
+    def test_webdriver_exception_returns_none(self):
+        """Test that a WebDriverException causes fetch_with_selenium to return None."""
+        from selenium.common.exceptions import WebDriverException
+        fetcher = _fetcher()
+        with self._chrome_patch(exception=WebDriverException("chromedriver missing")):
+            result = fetcher.fetch_with_selenium("https://example.com")
+        assert result is None
+
+
+class TestFetchHtml:
+    """Tests for the high-level fetch_html() routing logic."""
+
+    def test_static_page_returns_cloudscraper_html(self):
+        """Test that a normal static page is returned directly from cloudscraper."""
+        fetcher = _fetcher()
+        good_html = "<html><body>" + "x" * 200 + "</body></html>"
+        fetcher.fetch_with_cloudscraper = MagicMock(return_value=good_html)
+        fetcher.detector.detect = MagicMock(return_value={"is_spa": False})
+        fetcher._save_raw_html = MagicMock()
+        result = fetcher.fetch_html("https://example.com")
+        assert result == good_html
+        fetcher.fetch_with_cloudscraper.assert_called_once()
+
+    def test_spa_detected_falls_through_to_selenium(self):
+        """Test that a detected SPA skips the cloudscraper result and falls through to Selenium."""
+        fetcher = _fetcher()
+        good_html = "<html><body>" + "x" * 200 + "</body></html>"
+        selenium_html = "<html><body>Rendered SPA " + "y" * 200 + "</body></html>"
+        fetcher.fetch_with_cloudscraper = MagicMock(return_value=good_html)
+        fetcher.detector.detect = MagicMock(
+            return_value={"is_spa": True, "framework": "Next.js", "reason": "next-data"}
+        )
+        fetcher.fetch_with_selenium = MagicMock(return_value=selenium_html)
+        fetcher._save_raw_html = MagicMock()
+        result = fetcher.fetch_html("https://spa.example.com")
+        assert result == selenium_html
+
+    def test_short_cloudscraper_response_falls_through_to_selenium(self):
+        """Test that a cloudscraper response shorter than 100 chars triggers Selenium fallback."""
+        fetcher = _fetcher()
+        fetcher.fetch_with_cloudscraper = MagicMock(return_value="<html></html>")
+        selenium_html = "<html><body>" + "z" * 200 + "</body></html>"
+        fetcher.fetch_with_selenium = MagicMock(return_value=selenium_html)
+        fetcher._save_raw_html = MagicMock()
+        result = fetcher.fetch_html("https://example.com")
+        assert result == selenium_html
+
+    def test_both_methods_fail_raises_exception(self):
+        """Test that fetch_html raises an exception when both cloudscraper and Selenium fail."""
+        import pytest
+        fetcher = _fetcher()
+        fetcher.fetch_with_cloudscraper = MagicMock(return_value=None)
+        fetcher.fetch_with_selenium = MagicMock(return_value=None)
+        with pytest.raises(Exception, match="Failed to fetch HTML"):
+            fetcher.fetch_html("https://unreachable.example.com")
+
+    def test_cloudscraper_none_fallback_to_selenium(self):
+        """Test that a None result from cloudscraper triggers the Selenium fallback."""
+        fetcher = _fetcher()
+        selenium_html = "<html><body>" + "a" * 200 + "</body></html>"
+        fetcher.fetch_with_cloudscraper = MagicMock(return_value=None)
+        fetcher.fetch_with_selenium = MagicMock(return_value=selenium_html)
+        fetcher._save_raw_html = MagicMock()
+        result = fetcher.fetch_html("https://example.com")
+        assert result == selenium_html

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,139 @@
+"""Tests for LLMClient and _normalize_model in browser_agent/agent/llm.py."""
+
+from unittest.mock import MagicMock, patch
+
+from browsegenie.core.browser_agent.agent.llm import LLMClient, _normalize_model
+
+
+class TestNormalizeModel:
+    """Tests for the _normalize_model() routing-prefix helper."""
+
+    def test_google_prefix_added(self):
+        """Test that provider='google' prepends 'gemini/' to the model name."""
+        assert _normalize_model("google", "gemini-flash") == "gemini/gemini-flash"
+
+    def test_ollama_prefix_added(self):
+        """Test that provider='ollama' prepends 'ollama/' to the model name."""
+        assert _normalize_model("ollama", "llama3") == "ollama/llama3"
+
+    def test_deepseek_prefix_added(self):
+        """Test that provider='deepseek' prepends 'deepseek/' to the model name."""
+        assert _normalize_model("deepseek", "deepseek-chat") == "deepseek/deepseek-chat"
+
+    def test_mistral_prefix_added(self):
+        """Test that provider='mistral' prepends 'mistral/' to the model name."""
+        assert _normalize_model("mistral", "mistral-7b") == "mistral/mistral-7b"
+
+    def test_cohere_prefix_added(self):
+        """Test that provider='cohere' prepends 'cohere/' to the model name."""
+        assert _normalize_model("cohere", "command-r") == "cohere/command-r"
+
+    def test_xai_prefix_added(self):
+        """Test that provider='xai' prepends 'xai/' to the model name."""
+        assert _normalize_model("xai", "grok-2") == "xai/grok-2"
+
+    def test_already_prefixed_not_doubled(self):
+        """Test that a model already starting with the expected prefix is not double-prefixed."""
+        assert _normalize_model("google", "gemini/gemini-flash") == "gemini/gemini-flash"
+
+    def test_unknown_provider_passthrough(self):
+        """Test that an unrecognised provider leaves the model name unchanged."""
+        assert _normalize_model("openai", "gpt-4o") == "gpt-4o"
+
+    def test_empty_provider_passthrough(self):
+        """Test that an empty provider string leaves the model name unchanged."""
+        assert _normalize_model("", "gpt-4o") == "gpt-4o"
+
+
+class TestLLMClient:
+    """Tests for the LLMClient wrapper around litellm."""
+
+    def setup_method(self):
+        """Create a fresh LLMClient for each test."""
+        self.client = LLMClient(model="gpt-4o", provider="openai", api_key="sk-test")
+
+    def _mock_response(self, content="ok"):
+        """Return a mock litellm response object with a single choice."""
+        resp = MagicMock()
+        resp.choices[0].message.content = content
+        return resp
+
+    def test_model_property_reflects_normalized_name(self):
+        """Test that the model property returns the provider-prefixed model name."""
+        client = LLMClient(model="gemini-flash", provider="google")
+        assert client.model == "gemini/gemini-flash"
+
+    def test_model_property_openai_no_prefix(self):
+        """Test that openai models pass through without a prefix because openai is not in PROVIDER_PREFIXES."""
+        client = LLMClient(model="gpt-4o", provider="openai")
+        assert client.model == "gpt-4o"
+
+    def test_complete_calls_litellm(self):
+        """Test that complete() calls litellm.completion with model, messages, tools, and api_key."""
+        with patch(
+            "browsegenie.core.browser_agent.agent.llm.litellm.completion"
+        ) as mock_comp:
+            mock_comp.return_value = self._mock_response()
+            self.client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "t"}],
+            )
+            kwargs = mock_comp.call_args[1]
+            assert kwargs["model"] == "gpt-4o"
+            assert kwargs["api_key"] == "sk-test"
+            assert "tools" in kwargs
+
+    def test_complete_no_api_key_omits_api_key_kwarg(self):
+        """Test that complete() omits the api_key kwarg when no key was provided."""
+        client = LLMClient(model="gpt-4o")
+        with patch(
+            "browsegenie.core.browser_agent.agent.llm.litellm.completion"
+        ) as mock_comp:
+            mock_comp.return_value = self._mock_response()
+            client.complete(messages=[], tools=[])
+            assert "api_key" not in mock_comp.call_args[1]
+
+    def test_complete_text_returns_content_string(self):
+        """Test that complete_text() returns the content string from the first choice."""
+        with patch(
+            "browsegenie.core.browser_agent.agent.llm.litellm.completion"
+        ) as mock_comp:
+            mock_comp.return_value = self._mock_response(content="Hello World")
+            result = self.client.complete_text(
+                messages=[{"role": "user", "content": "say hi"}]
+            )
+            assert result == "Hello World"
+
+    def test_token_stats_returns_dict(self):
+        """Test that token_stats() returns a dict summarising usage."""
+        stats = self.client.token_stats()
+        assert isinstance(stats, dict)
+
+    def test_token_stats_accumulate_across_calls(self):
+        """Test that token usage is accumulated from multiple complete() calls."""
+        from browsegenie.core.token_usage import ApiCallTokens
+
+        with patch(
+            "browsegenie.core.browser_agent.agent.llm.litellm.completion"
+        ) as mock_comp, patch(
+            "browsegenie.core.browser_agent.agent.llm.extract_litellm_tokens"
+        ) as mock_tok:
+            mock_comp.return_value = self._mock_response()
+            mock_tok.return_value = ApiCallTokens(
+                model="gpt-4o", prompt_tokens=10, completion_tokens=5, total_tokens=15
+            )
+            self.client.complete(messages=[], tools=[])
+            self.client.complete(messages=[], tools=[])
+            assert len(self.client._calls) == 2
+
+    def test_none_tokens_not_appended(self):
+        """Test that a None token result from extract_litellm_tokens is not added to _calls."""
+        with patch(
+            "browsegenie.core.browser_agent.agent.llm.litellm.completion"
+        ) as mock_comp, patch(
+            "browsegenie.core.browser_agent.agent.llm.extract_litellm_tokens"
+        ) as mock_tok:
+            mock_comp.return_value = self._mock_response()
+            mock_tok.return_value = None
+            self.client.complete(messages=[], tools=[])
+            assert self.client._calls == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -76,15 +76,13 @@ class TestHandleListTools:
 
     def test_exception_raises_configuration_error(self):
         """Test that a ToolManager failure is re-raised as ConfigurationError."""
+        import pytest
         server = BrowseGenieMCPServer()
         server._tool_manager.get_all_tools = MagicMock(
             side_effect=Exception("tool manager down")
         )
-        try:
+        with pytest.raises(ConfigurationError, match="tool manager down"):
             _run(server._handle_list_tools())
-            assert False, "Should have raised"
-        except ConfigurationError as exc:
-            assert "tool manager down" in str(exc)
 
 
 class TestHandleCallTool:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,123 @@
+"""Tests for BrowseGenieMCPServer in core/mcp/server.py."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from browsegenie.core.mcp.server import BrowseGenieMCPServer
+from browsegenie.core.mcp.exceptions import ConfigurationError
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+class TestBrowseGenieMCPServerInit:
+    """Tests for BrowseGenieMCPServer initialisation."""
+
+    def test_server_name_is_browsegenie(self):
+        """Test that the server_name attribute is set to 'browsegenie'."""
+        server = BrowseGenieMCPServer()
+        assert server.server_name == "browsegenie"
+
+    def test_server_version_matches_package(self):
+        """Test that server_version matches the installed package version."""
+        from browsegenie import __version__
+        server = BrowseGenieMCPServer()
+        assert server.server_version == __version__
+
+    def test_tool_manager_property_returns_manager(self):
+        """Test that the tool_manager property returns a ToolManager instance."""
+        from browsegenie.core.mcp.tools import ToolManager
+        server = BrowseGenieMCPServer()
+        assert isinstance(server.tool_manager, ToolManager)
+
+
+class TestGetScraper:
+    """Tests for the lazy scraper accessor."""
+
+    def test_get_scraper_creates_instance_on_first_call(self):
+        """Test that get_scraper() constructs a BrowseGenie instance when none exists."""
+        server = BrowseGenieMCPServer()
+        with patch("browsegenie.scraper.BrowseGenie") as MockBG:
+            MockBG.return_value = MagicMock()
+            scraper = server.get_scraper()
+            MockBG.assert_called_once()
+            assert scraper is server._scraper_instance
+
+    def test_get_scraper_memoizes(self):
+        """Test that a second call to get_scraper() returns the same instance without constructing again."""
+        server = BrowseGenieMCPServer()
+        with patch("browsegenie.scraper.BrowseGenie") as MockBG:
+            mock_instance = MagicMock()
+            MockBG.return_value = mock_instance
+            first = server.get_scraper()
+            second = server.get_scraper()
+            assert first is second
+            MockBG.assert_called_once()
+
+    def test_set_scraper_instance_overrides_lazy(self):
+        """Test that set_scraper_instance() replaces the stored scraper."""
+        server = BrowseGenieMCPServer()
+        custom_scraper = MagicMock()
+        server.set_scraper_instance(custom_scraper)
+        assert server.get_scraper() is custom_scraper
+
+
+class TestHandleListTools:
+    """Tests for _handle_list_tools."""
+
+    def test_returns_tool_list(self):
+        """Test that _handle_list_tools() returns the list of all registered MCP tools."""
+        server = BrowseGenieMCPServer()
+        tools = _run(server._handle_list_tools())
+        assert len(tools) == 5
+
+    def test_exception_raises_configuration_error(self):
+        """Test that a ToolManager failure is re-raised as ConfigurationError."""
+        server = BrowseGenieMCPServer()
+        server._tool_manager.get_all_tools = MagicMock(
+            side_effect=Exception("tool manager down")
+        )
+        try:
+            _run(server._handle_list_tools())
+            assert False, "Should have raised"
+        except ConfigurationError as exc:
+            assert "tool manager down" in str(exc)
+
+
+class TestHandleCallTool:
+    """Tests for _handle_call_tool."""
+
+    def test_delegates_to_tool_manager(self):
+        """Test that _handle_call_tool calls ToolManager.execute_tool with name and arguments."""
+        server = BrowseGenieMCPServer()
+        server.set_scraper_instance(MagicMock())
+        mock_result = [MagicMock()]
+        server._tool_manager.execute_tool = AsyncMock(return_value=mock_result)
+        result = _run(server._handle_call_tool("scrape_url", {"url": "https://x.com/p"}))
+        server._tool_manager.execute_tool.assert_called_once()
+        assert result is mock_result
+
+    def test_exception_returns_error_text_content(self):
+        """Test that an unexpected exception during call_tool is returned as an error TextContent."""
+        server = BrowseGenieMCPServer()
+        server.set_scraper_instance(MagicMock())
+        server._tool_manager.execute_tool = AsyncMock(
+            side_effect=Exception("unexpected crash")
+        )
+        result = _run(server._handle_call_tool("scrape_url", {}))
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+class TestGetCapabilities:
+    """Tests for get_capabilities()."""
+
+    def test_get_capabilities_returns_dict(self):
+        """Test that get_capabilities() returns a non-None capabilities object."""
+        server = BrowseGenieMCPServer()
+        caps = server.get_capabilities()
+        assert caps is not None

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,264 @@
+"""Tests for MCP tool definitions and ToolManager in core/mcp/tools.py."""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+from browsegenie.core.mcp.tools import (
+    ClearCacheTool,
+    ConfigureScraperTool,
+    GetScraperInfoTool,
+    ScrapeMultipleURLsTool,
+    ScrapeURLTool,
+    ToolManager,
+)
+
+
+def _run(coro):
+    """Run an async coroutine synchronously for use in non-async tests."""
+    return asyncio.run(coro)
+
+
+def _scraper():
+    """Return a mock BrowseGenie scraper instance."""
+    s = MagicMock()
+    s.scrape_url.return_value = {"title": "Test"}
+    s.scrape_multiple_urls.return_value = [{"title": "A"}, {"title": "B"}]
+    s.get_model_name.return_value = "gemini-2.5-flash"
+    s.get_fields.return_value = ["title"]
+    s.get_cache_stats.return_value = {"entries": 3}
+    s.clear_cache.return_value = None
+    s.cleanup_old_cache.return_value = 2
+    return s
+
+
+# ── ScrapeURLTool ─────────────────────────────────────────────────────────────
+
+class TestScrapeURLTool:
+    """Tests for the ScrapeURLTool MCP tool."""
+
+    def setup_method(self):
+        """Set up a fresh ScrapeURLTool instance for each test."""
+        self.tool = ScrapeURLTool()
+
+    def test_name_is_scrape_url(self):
+        """Test that the tool name is 'scrape_url'."""
+        assert self.tool.name == "scrape_url"
+
+    def test_description_is_nonempty(self):
+        """Test that the tool has a non-empty description."""
+        assert len(self.tool.description) > 0
+
+    def test_input_schema_requires_url(self):
+        """Test that the input schema declares url as a required field."""
+        assert "url" in self.tool.input_schema["required"]
+
+    def test_execute_happy_path(self):
+        """Test that execute() returns TextContent with JSON-serialised scrape results."""
+        scraper = _scraper()
+        result = _run(self.tool.execute({"url": "https://example.com/page"}, scraper))
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert data == {"title": "Test"}
+
+    def test_execute_invalid_url_returns_error_content(self):
+        """Test that a URL that fails validation returns an error TextContent."""
+        scraper = _scraper()
+        result = _run(self.tool.execute({"url": "not-a-url"}, scraper))
+        assert len(result) == 1
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+    def test_execute_sets_fields_when_provided(self):
+        """Test that fields in arguments are forwarded to scraper.set_fields."""
+        scraper = _scraper()
+        _run(self.tool.execute(
+            {"url": "https://example.com/page", "fields": ["title", "price"]}, scraper
+        ))
+        scraper.set_fields.assert_called_once_with(["title", "price"])
+
+    def test_execute_exception_returns_error_content(self):
+        """Test that an unexpected exception during execution is returned as an error TextContent."""
+        scraper = _scraper()
+        scraper.scrape_url.side_effect = Exception("network error")
+        result = _run(self.tool.execute({"url": "https://example.com/page"}, scraper))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ── ScrapeMultipleURLsTool ────────────────────────────────────────────────────
+
+class TestScrapeMultipleURLsTool:
+    """Tests for the ScrapeMultipleURLsTool MCP tool."""
+
+    def setup_method(self):
+        """Set up a fresh ScrapeMultipleURLsTool instance for each test."""
+        self.tool = ScrapeMultipleURLsTool()
+
+    def test_name_is_scrape_multiple_urls(self):
+        """Test that the tool name is 'scrape_multiple_urls'."""
+        assert self.tool.name == "scrape_multiple_urls"
+
+    def test_input_schema_requires_urls(self):
+        """Test that the input schema declares urls as a required field."""
+        assert "urls" in self.tool.input_schema["required"]
+
+    def test_execute_happy_path(self):
+        """Test that execute() returns TextContent with a list of scrape results."""
+        scraper = _scraper()
+        result = _run(self.tool.execute(
+            {"urls": ["https://a.com/p", "https://b.com/p"]}, scraper
+        ))
+        data = json.loads(result[0].text)
+        assert isinstance(data, list)
+
+    def test_execute_exception_returns_error(self):
+        """Test that an exception from scrape_multiple_urls is returned as an error TextContent."""
+        scraper = _scraper()
+        scraper.scrape_multiple_urls.side_effect = Exception("boom")
+        result = _run(self.tool.execute(
+            {"urls": ["https://a.com/p"]}, scraper
+        ))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ── ConfigureScraperTool ──────────────────────────────────────────────────────
+
+class TestConfigureScraperTool:
+    """Tests for the ConfigureScraperTool MCP tool."""
+
+    def setup_method(self):
+        """Set up a fresh ConfigureScraperTool instance for each test."""
+        self.tool = ConfigureScraperTool()
+
+    def test_name_is_configure_scraper(self):
+        """Test that the tool name is 'configure_scraper'."""
+        assert self.tool.name == "configure_scraper"
+
+    def test_execute_returns_config(self):
+        """Test that execute() returns a configuration status dict as TextContent."""
+        with patch("browsegenie.scraper.BrowseGenie") as MockBG:
+            mock_instance = MagicMock()
+            mock_instance.get_model_name.return_value = "gemini-2.5-flash"
+            mock_instance.get_fields.return_value = []
+            MockBG.return_value = mock_instance
+            result = _run(self.tool.execute({}, MagicMock()))
+        data = json.loads(result[0].text)
+        assert data["status"] == "configured"
+
+    def test_execute_exception_returns_error(self):
+        """Test that an exception during configure returns an error TextContent."""
+        with patch(
+            "browsegenie.scraper.BrowseGenie",
+            side_effect=Exception("config fail"),
+        ):
+            result = _run(self.tool.execute({}, MagicMock()))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ── GetScraperInfoTool ────────────────────────────────────────────────────────
+
+class TestGetScraperInfoTool:
+    """Tests for the GetScraperInfoTool MCP tool."""
+
+    def setup_method(self):
+        """Set up a fresh GetScraperInfoTool instance for each test."""
+        self.tool = GetScraperInfoTool()
+
+    def test_name_is_get_scraper_info(self):
+        """Test that the tool name is 'get_scraper_info'."""
+        assert self.tool.name == "get_scraper_info"
+
+    def test_execute_returns_model_and_fields(self):
+        """Test that execute() returns model_name and fields from the scraper."""
+        scraper = _scraper()
+        result = _run(self.tool.execute({}, scraper))
+        data = json.loads(result[0].text)
+        assert data["model_name"] == "gemini-2.5-flash"
+        assert data["fields"] == ["title"]
+
+    def test_execute_exception_returns_error(self):
+        """Test that an exception from the scraper is returned as an error TextContent."""
+        scraper = MagicMock()
+        scraper.get_model_name.side_effect = Exception("info error")
+        result = _run(self.tool.execute({}, scraper))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ── ClearCacheTool ────────────────────────────────────────────────────────────
+
+class TestClearCacheTool:
+    """Tests for the ClearCacheTool MCP tool."""
+
+    def setup_method(self):
+        """Set up a fresh ClearCacheTool instance for each test."""
+        self.tool = ClearCacheTool()
+
+    def test_name_is_clear_cache(self):
+        """Test that the tool name is 'clear_cache'."""
+        assert self.tool.name == "clear_cache"
+
+    def test_execute_days_zero_calls_clear_cache(self):
+        """Test that days_old=0 calls scraper.clear_cache() to remove all entries."""
+        scraper = _scraper()
+        result = _run(self.tool.execute({"days_old": 0}, scraper))
+        scraper.clear_cache.assert_called_once()
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+
+    def test_execute_days_positive_calls_cleanup_old_cache(self):
+        """Test that days_old>0 calls scraper.cleanup_old_cache() with the given days."""
+        scraper = _scraper()
+        result = _run(self.tool.execute({"days_old": 7}, scraper))
+        scraper.cleanup_old_cache.assert_called_once_with(7)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+
+    def test_execute_exception_returns_error(self):
+        """Test that an exception during cache clearing returns an error TextContent."""
+        scraper = _scraper()
+        scraper.clear_cache.side_effect = Exception("db locked")
+        result = _run(self.tool.execute({"days_old": 0}, scraper))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ── ToolManager ───────────────────────────────────────────────────────────────
+
+class TestToolManager:
+    """Tests for the ToolManager registry class."""
+
+    def setup_method(self):
+        """Create a fresh ToolManager for each test."""
+        self.manager = ToolManager()
+
+    def test_get_all_tools_returns_five_tools(self):
+        """Test that get_all_tools() returns all five registered MCP Tool objects."""
+        tools = self.manager.get_all_tools()
+        assert len(tools) == 5
+
+    def test_get_tool_by_name(self):
+        """Test that get_tool() returns the correct tool instance by name."""
+        tool = self.manager.get_tool("scrape_url")
+        assert tool is not None
+        assert tool.name == "scrape_url"
+
+    def test_get_tool_unknown_returns_none(self):
+        """Test that get_tool() returns None for an unregistered tool name."""
+        assert self.manager.get_tool("nonexistent") is None
+
+    def test_execute_tool_unknown_returns_error_content(self):
+        """Test that execute_tool() with an unknown name returns an error TextContent."""
+        result = _run(self.manager.execute_tool("ghost_tool", {}, MagicMock()))
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+    def test_to_mcp_tool_shape(self):
+        """Test that each tool converts to an MCP Tool with name, description, and inputSchema."""
+        for mcp_tool in self.manager.get_all_tools():
+            assert mcp_tool.name
+            assert mcp_tool.description
+            assert mcp_tool.inputSchema

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -61,7 +61,7 @@ class TestCapturePageState:
         """Test that the snapshot string includes the current URL and page title."""
         browser = self._make_browser(url="https://test.com", title="Test Page")
         result = capture_page_state(browser)
-        assert "https://test.com" in result
+        assert "test.com" in result
         assert "Test Page" in result
 
     def test_contains_visible_text(self):
@@ -83,7 +83,7 @@ class TestCapturePageState:
         browser.page.title.side_effect = Exception("boom")
         browser.current_url.return_value = "https://fallback.com"
         result = capture_page_state(browser)
-        assert "https://fallback.com" in result
+        assert "fallback.com" in result
 
     def test_contains_elements_block(self):
         """Test that the snapshot contains an Elements section."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,94 @@
+"""Tests for agent/prompts.py: SYSTEM_PROMPT constant and capture_page_state function."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.agent.prompts import SYSTEM_PROMPT, capture_page_state
+from browsegenie.core.browser_agent.heuristic_resolver import KNOWN_TARGETS
+
+
+class TestSystemPrompt:
+    """Tests for the SYSTEM_PROMPT constant."""
+
+    def test_system_prompt_is_nonempty_string(self):
+        """Test that SYSTEM_PROMPT is a non-empty string of reasonable length."""
+        assert isinstance(SYSTEM_PROMPT, str)
+        assert len(SYSTEM_PROMPT) > 100
+
+    def test_all_known_targets_in_prompt(self):
+        """Test that every KNOWN_TARGETS entry is mentioned in SYSTEM_PROMPT."""
+        for target in KNOWN_TARGETS:
+            assert target in SYSTEM_PROMPT, f"'{target}' missing from SYSTEM_PROMPT"
+
+    def test_prompt_includes_done_instruction(self):
+        """Test that SYSTEM_PROMPT instructs the agent to call done() when finished."""
+        assert "done" in SYSTEM_PROMPT.lower()
+
+    def test_prompt_includes_plan_instruction(self):
+        """Test that SYSTEM_PROMPT instructs the agent to call plan() first."""
+        assert "plan" in SYSTEM_PROMPT
+
+
+class TestCapturePageState:
+    """Tests for the capture_page_state() snapshot function."""
+
+    def _make_browser(
+        self,
+        url="https://example.com",
+        title="Example",
+        text="visible text",
+        elements=None,
+    ):
+        """Return a fake browser stub wired up for capture_page_state."""
+        if elements is None:
+            elements = [{"index": 0, "tag": "button", "text": "Submit"}]
+        browser = MagicMock()
+        browser.page.url = url
+        browser.page.title.return_value = title
+        body = MagicMock()
+        body.inner_text.return_value = text
+        browser.page.query_selector.return_value = body
+        browser.page.evaluate.return_value = elements
+        return browser
+
+    def test_returns_nonempty_string(self):
+        """Test that capture_page_state returns a non-empty string."""
+        browser = self._make_browser()
+        result = capture_page_state(browser)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_contains_url_and_title(self):
+        """Test that the snapshot string includes the current URL and page title."""
+        browser = self._make_browser(url="https://test.com", title="Test Page")
+        result = capture_page_state(browser)
+        assert "https://test.com" in result
+        assert "Test Page" in result
+
+    def test_contains_visible_text(self):
+        """Test that the snapshot string includes the visible body text."""
+        browser = self._make_browser(text="hello world content")
+        result = capture_page_state(browser)
+        assert "hello world content" in result
+
+    def test_text_capped_at_1500_chars(self):
+        """Test that body text in the snapshot is truncated to at most 1500 characters."""
+        browser = self._make_browser(text="z" * 3000)
+        result = capture_page_state(browser)
+        assert "z" * 1501 not in result
+
+    def test_exception_falls_back_to_current_url(self):
+        """Test that an exception during snapshot capture falls back to the URL-only format."""
+        browser = MagicMock()
+        browser.page.url = "bad-page"
+        browser.page.title.side_effect = Exception("boom")
+        browser.current_url.return_value = "https://fallback.com"
+        result = capture_page_state(browser)
+        assert "https://fallback.com" in result
+
+    def test_contains_elements_block(self):
+        """Test that the snapshot contains an Elements section."""
+        browser = self._make_browser(
+            elements=[{"index": 0, "tag": "input", "text": "Search"}]
+        )
+        result = capture_page_state(browser)
+        assert "Elements" in result

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -1,0 +1,43 @@
+"""Tests for thin shim modules: browsegenie/mcp_server.py and browsegenie/web_ui.py."""
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+
+class TestMcpServerShim:
+    """Tests for the mcp_server.py entry-point shim."""
+
+    def test_main_sync_calls_asyncio_run(self):
+        """Test that main_sync() calls asyncio.run() with the main coroutine."""
+        with patch(
+            "browsegenie.mcp_server.create_and_run_server",
+            new_callable=AsyncMock,
+        ) as mock_server:
+            from browsegenie.mcp_server import main_sync
+            main_sync()
+            mock_server.assert_called_once()
+
+    def test_main_is_coroutine(self):
+        """Test that main() is an async function that can be awaited."""
+        from browsegenie.mcp_server import main
+        assert inspect.iscoroutinefunction(main)
+
+
+class TestWebUiShim:
+    """Tests for the web_ui.py re-export shim."""
+
+    def test_create_app_exported(self):
+        """Test that create_app is importable from the browsegenie.web_ui shim."""
+        from browsegenie.web_ui import create_app
+        assert callable(create_app)
+
+    def test_main_exported(self):
+        """Test that main is importable from the browsegenie.web_ui shim."""
+        from browsegenie.web_ui import main
+        assert callable(main)
+
+    def test_all_lists_expected_names(self):
+        """Test that __all__ contains both 'main' and 'create_app'."""
+        import browsegenie.web_ui as shim
+        assert "main" in shim.__all__
+        assert "create_app" in shim.__all__

--- a/tests/test_tools_extraction.py
+++ b/tests/test_tools_extraction.py
@@ -1,0 +1,135 @@
+"""Tests for browser-agent extraction tools: get_page_content, find_elements, get_interactive_elements, execute_js."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.tools.extraction import (
+    execute_js,
+    find_elements,
+    get_interactive_elements,
+    get_page_content,
+)
+
+
+def _page(url="https://example.com", title="Example", text="Some body text"):
+    """Return a mock Playwright Page configured for extraction tests."""
+    page = MagicMock()
+    page.url = url
+    page.title.return_value = title
+    body = MagicMock()
+    body.inner_text.return_value = text
+    page.query_selector.return_value = body
+    return page
+
+
+class TestGetPageContent:
+    """Tests for the get_page_content() extraction tool."""
+
+    def test_returns_url_title_text(self):
+        """Test that get_page_content returns url, title, and text keys."""
+        page = _page()
+        result = get_page_content(page)
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Example"
+        assert "Some body text" in result["text"]
+
+    def test_text_truncated_to_3000_chars(self):
+        """Test that visible text is capped at 3000 characters."""
+        long_text = "x" * 5000
+        page = _page(text=long_text)
+        result = get_page_content(page)
+        assert len(result["text"]) <= 3000
+
+    def test_body_none_returns_empty_text(self):
+        """Test that get_page_content returns an empty text string when body element is None."""
+        page = _page()
+        page.query_selector.return_value = None
+        result = get_page_content(page)
+        assert result["text"] == ""
+
+    def test_inner_text_exception_returns_empty_text(self):
+        """Test that get_page_content returns empty text when inner_text raises an exception."""
+        page = _page()
+        page.query_selector.return_value.inner_text.side_effect = Exception("DOM error")
+        result = get_page_content(page)
+        assert result["text"] == ""
+
+
+class TestFindElements:
+    """Tests for the find_elements() extraction tool."""
+
+    def test_returns_selector_total_and_results(self):
+        """Test that find_elements returns selector, total, and results from page.evaluate."""
+        page = MagicMock()
+        page.evaluate.return_value = {
+            "total": 2,
+            "results": [{"tag": "a"}, {"tag": "a"}],
+        }
+        result = find_elements(page, "a")
+        assert result["selector"] == "a"
+        assert result["total"] == 2
+        assert len(result["results"]) == 2
+
+    def test_exception_returns_error_dict(self):
+        """Test that find_elements returns an error dict when page.evaluate raises."""
+        page = MagicMock()
+        page.evaluate.side_effect = Exception("JS error")
+        result = find_elements(page, ".bad-selector")
+        assert "error" in result
+        assert result["selector"] == ".bad-selector"
+
+    def test_limit_forwarded_to_evaluate(self):
+        """Test that the limit parameter is included in the arguments passed to evaluate."""
+        page = MagicMock()
+        page.evaluate.return_value = {"total": 0, "results": []}
+        find_elements(page, "div", limit=5)
+        call_args = page.evaluate.call_args
+        assert 5 in call_args[0][1].values()
+
+
+class TestGetInteractiveElements:
+    """Tests for the get_interactive_elements() extraction tool."""
+
+    def test_returns_elements_and_count(self):
+        """Test that get_interactive_elements returns an elements list and the correct count."""
+        page = MagicMock()
+        page.evaluate.return_value = [
+            {"index": 0, "tag": "button"},
+            {"index": 1, "tag": "input"},
+        ]
+        result = get_interactive_elements(page)
+        assert result["count"] == 2
+        assert len(result["elements"]) == 2
+
+    def test_empty_page_returns_zero_count(self):
+        """Test that an empty elements list yields count=0."""
+        page = MagicMock()
+        page.evaluate.return_value = []
+        result = get_interactive_elements(page)
+        assert result["count"] == 0
+        assert result["elements"] == []
+
+
+class TestExecuteJs:
+    """Tests for the execute_js() extraction tool."""
+
+    def test_happy_path_returns_result(self):
+        """Test that execute_js returns a result dict with the stringified evaluate value."""
+        page = MagicMock()
+        page.evaluate.return_value = 42
+        result = execute_js(page, "1 + 41")
+        assert result["result"] == "42"
+
+    def test_exception_returns_error_dict(self):
+        """Test that execute_js returns an error dict when page.evaluate raises."""
+        page = MagicMock()
+        page.evaluate.side_effect = Exception("syntax error")
+        result = execute_js(page, "~~~")
+        assert "error" in result
+        assert "syntax error" in result["error"]
+
+    def test_result_truncated_to_5000(self):
+        """Test that the stringified result is capped at 5000 characters."""
+        page = MagicMock()
+        page.evaluate.return_value = "y" * 10000
+        result = execute_js(page, "bigString()")
+        assert len(result["result"]) <= 5000

--- a/tests/test_tools_interaction.py
+++ b/tests/test_tools_interaction.py
@@ -1,0 +1,198 @@
+"""Tests for browser-agent interaction tools: click, fill, press_key, hover, select_option, drag_and_drop."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.tools.interaction import (
+    click,
+    drag_and_drop,
+    fill,
+    hover,
+    press_key,
+    select_option,
+)
+
+
+def _page():
+    """Return a fully wired mock Playwright Page."""
+    return MagicMock()
+
+
+def _handle_with_element(el=None):
+    """Return a mock evaluate_handle result whose as_element() returns el."""
+    handle = MagicMock()
+    handle.as_element.return_value = el
+    return handle
+
+
+class TestClick:
+    """Tests for the click() interaction tool."""
+
+    def test_click_by_selector(self):
+        """Test that click(selector) uses locator().first to attempt the click."""
+        page = _page()
+        result = click(page, selector="#submit")
+        page.locator.assert_called_once_with("#submit")
+        assert result["clicked"] == "#submit"
+
+    def test_click_by_coordinates(self):
+        """Test that click(x, y) delegates to page.mouse.click."""
+        page = _page()
+        result = click(page, x=100, y=200)
+        page.mouse.click.assert_called_once_with(100, 200)
+        assert "100" in result["clicked"] and "200" in result["clicked"]
+
+    def test_click_by_index_out_of_range(self):
+        """Test that click(index) returns an error dict when no element is at that index."""
+        page = _page()
+        page.evaluate_handle.return_value = _handle_with_element(None)
+        result = click(page, index=99)
+        assert "error" in result
+        assert "99" in result["error"]
+
+    def test_click_by_index_success(self):
+        """Test that click(index) scrolls into view and clicks the resolved element."""
+        page = _page()
+        el = MagicMock()
+        page.evaluate_handle.return_value = _handle_with_element(el)
+        result = click(page, index=0)
+        el.click.assert_called_once()
+        assert "element_index=0" in result["clicked"]
+
+    def test_click_no_args_returns_error(self):
+        """Test that calling click with no targeting argument returns an error dict."""
+        page = _page()
+        result = click(page)
+        assert "error" in result
+
+    def test_click_selector_locator_failure_uses_js_fallback(self):
+        """Test that a locator click failure triggers the JS evaluate fallback."""
+        page = _page()
+        page.locator.return_value.first.click.side_effect = Exception("not actionable")
+        result = click(page, selector="#btn")
+        page.evaluate.assert_called()
+        assert result["clicked"] == "#btn"
+
+    def test_click_index_scroll_failure_still_clicks(self):
+        """Test that a scroll_into_view failure does not prevent the element from being clicked."""
+        page = _page()
+        el = MagicMock()
+        el.scroll_into_view_if_needed.side_effect = Exception("scroll fail")
+        page.evaluate_handle.return_value = _handle_with_element(el)
+        result = click(page, index=0)
+        el.click.assert_called_once()
+        assert "element_index=0" in result["clicked"]
+
+
+class TestFill:
+    """Tests for the fill() interaction tool."""
+
+    def test_fill_by_selector(self):
+        """Test that fill(selector) calls page.fill to clear and page.type to input text."""
+        page = _page()
+        result = fill(page, text="hello", selector="#input")
+        page.fill.assert_called_once_with("#input", "", timeout=10000)
+        page.type.assert_called_once_with("#input", "hello", delay=30)
+        assert result["filled"] == "#input"
+        assert result["text"] == "hello"
+
+    def test_fill_no_clear(self):
+        """Test that fill with clear_first=False skips the initial page.fill clear step."""
+        page = _page()
+        fill(page, text="world", selector="#input", clear_first=False)
+        page.fill.assert_not_called()
+        page.type.assert_called_once()
+
+    def test_fill_by_index_success(self):
+        """Test that fill(index) resolves the element and types into it."""
+        page = _page()
+        el = MagicMock()
+        page.evaluate_handle.return_value = _handle_with_element(el)
+        result = fill(page, text="test", index=1, clear_first=True)
+        el.fill.assert_called_once_with("", timeout=10000)
+        el.type.assert_called_once_with("test", delay=30)
+        assert "element_index=1" in result["filled"]
+
+    def test_fill_by_index_out_of_range(self):
+        """Test that fill(index) returns an error dict when the index resolves to None."""
+        page = _page()
+        page.evaluate_handle.return_value = _handle_with_element(None)
+        result = fill(page, text="x", index=50)
+        assert "error" in result
+
+    def test_fill_no_args_returns_error(self):
+        """Test that fill with neither selector nor index returns an error dict."""
+        page = _page()
+        result = fill(page, text="orphan")
+        assert "error" in result
+
+
+class TestPressKey:
+    """Tests for the press_key() interaction tool."""
+
+    def test_press_key_no_selector(self):
+        """Test that press_key without a selector presses the key directly."""
+        page = _page()
+        result = press_key(page, key="Enter")
+        page.focus.assert_not_called()
+        page.keyboard.press.assert_called_once_with("Enter")
+        assert result["pressed"] == "Enter"
+
+    def test_press_key_with_selector_focuses_first(self):
+        """Test that press_key with a selector focuses the element before pressing the key."""
+        page = _page()
+        press_key(page, key="Tab", selector="#input")
+        page.focus.assert_called_once_with("#input", timeout=5000)
+        page.keyboard.press.assert_called_once_with("Tab")
+
+
+class TestHover:
+    """Tests for the hover() interaction tool."""
+
+    def test_hover_calls_page_hover(self):
+        """Test that hover delegates to page.hover with the correct selector and timeout."""
+        page = _page()
+        result = hover(page, selector=".menu-item")
+        page.hover.assert_called_once_with(".menu-item", timeout=10000)
+        assert result["hovered"] == ".menu-item"
+
+
+class TestSelectOption:
+    """Tests for the select_option() interaction tool."""
+
+    def test_select_by_value(self):
+        """Test that select_option by value calls page.select_option with the value kwarg."""
+        page = _page()
+        result = select_option(page, selector="#size", value="large")
+        page.select_option.assert_called_once_with(
+            "#size", value="large", timeout=10000
+        )
+        assert result["value"] == "large"
+
+    def test_select_by_label(self):
+        """Test that select_option by label calls page.select_option with the label kwarg."""
+        page = _page()
+        result = select_option(page, selector="#size", label="Large")
+        page.select_option.assert_called_once_with(
+            "#size", label="Large", timeout=10000
+        )
+        assert result["label"] == "Large"
+
+    def test_select_no_args_returns_error(self):
+        """Test that select_option with neither value nor label returns an error dict."""
+        page = _page()
+        result = select_option(page, selector="#size")
+        assert "error" in result
+
+
+class TestDragAndDrop:
+    """Tests for the drag_and_drop() interaction tool."""
+
+    def test_drag_and_drop_calls_page(self):
+        """Test that drag_and_drop delegates to page.drag_and_drop with source and target."""
+        page = _page()
+        result = drag_and_drop(page, source="#item", target="#slot")
+        page.drag_and_drop.assert_called_once_with(
+            "#item", "#slot", timeout=10000
+        )
+        assert result["dragged"] == "#item"
+        assert result["to"] == "#slot"

--- a/tests/test_tools_navigation.py
+++ b/tests/test_tools_navigation.py
@@ -1,0 +1,105 @@
+"""Tests for browser-agent navigation tools: navigate, go_back, go_forward, reload."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.tools.navigation import (
+    go_back,
+    go_forward,
+    navigate,
+    reload,
+)
+
+
+def _page(url="https://example.com", title="Example"):
+    """Return a mock Playwright Page with preset url and title."""
+    page = MagicMock()
+    page.url = url
+    page.title.return_value = title
+    return page
+
+
+class TestNavigate:
+    """Tests for the navigate() tool."""
+
+    def test_navigate_calls_goto(self):
+        """Test that navigate calls page.goto with the given URL."""
+        page = _page()
+        navigate(page, "https://example.com")
+        page.goto.assert_called_once_with(
+            "https://example.com", wait_until="load", timeout=30000
+        )
+
+    def test_navigate_returns_url_and_title(self):
+        """Test that navigate returns a dict with url and title keys."""
+        page = _page(url="https://example.com", title="Example Domain")
+        result = navigate(page, "https://example.com")
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Example Domain"
+
+    def test_navigate_networkidle_exception_swallowed(self):
+        """Test that a networkidle timeout is silently ignored and navigate still succeeds."""
+        page = _page()
+        page.wait_for_load_state.side_effect = Exception("networkidle timeout")
+        result = navigate(page, "https://example.com")
+        assert "url" in result
+
+    def test_navigate_calls_wait_for_load_state(self):
+        """Test that navigate attempts to wait for networkidle after goto."""
+        page = _page()
+        navigate(page, "https://example.com")
+        page.wait_for_load_state.assert_called_once_with("networkidle", timeout=5000)
+
+
+class TestGoBack:
+    """Tests for the go_back() tool."""
+
+    def test_go_back_calls_page_go_back(self):
+        """Test that go_back delegates to page.go_back with domcontentloaded."""
+        page = _page()
+        go_back(page)
+        page.go_back.assert_called_once_with(
+            wait_until="domcontentloaded", timeout=10000
+        )
+
+    def test_go_back_returns_url(self):
+        """Test that go_back returns a dict containing the current url."""
+        page = _page(url="https://previous.com")
+        result = go_back(page)
+        assert result["url"] == "https://previous.com"
+
+
+class TestGoForward:
+    """Tests for the go_forward() tool."""
+
+    def test_go_forward_calls_page_go_forward(self):
+        """Test that go_forward delegates to page.go_forward with domcontentloaded."""
+        page = _page()
+        go_forward(page)
+        page.go_forward.assert_called_once_with(
+            wait_until="domcontentloaded", timeout=10000
+        )
+
+    def test_go_forward_returns_url(self):
+        """Test that go_forward returns a dict containing the current url."""
+        page = _page(url="https://next.com")
+        result = go_forward(page)
+        assert result["url"] == "https://next.com"
+
+
+class TestReload:
+    """Tests for the reload() tool."""
+
+    def test_reload_calls_page_reload(self):
+        """Test that reload delegates to page.reload with domcontentloaded."""
+        page = _page()
+        reload(page)
+        page.reload.assert_called_once_with(
+            wait_until="domcontentloaded", timeout=15000
+        )
+
+    def test_reload_returns_url_and_title(self):
+        """Test that reload returns a dict with url and title keys."""
+        page = _page(url="https://example.com", title="Reloaded Page")
+        result = reload(page)
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Reloaded Page"

--- a/tests/test_tools_scroll.py
+++ b/tests/test_tools_scroll.py
@@ -1,0 +1,108 @@
+"""Tests for browser-agent scroll tools: scroll, scroll_to_element, scroll_to_bottom, scroll_to_top."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.tools.scroll import (
+    scroll,
+    scroll_to_bottom,
+    scroll_to_element,
+    scroll_to_top,
+)
+
+
+def _page():
+    """Return a mock Playwright Page."""
+    return MagicMock()
+
+
+class TestScroll:
+    """Tests for the scroll() tool."""
+
+    def test_scroll_down(self):
+        """Test that scroll('down') evaluates the correct scrollBy JS expression."""
+        page = _page()
+        result = scroll(page, direction="down", pixels=300)
+        page.evaluate.assert_called_once_with("window.scrollBy(0, 300)")
+        assert result["scrolled"] == "down"
+        assert result["pixels"] == 300
+
+    def test_scroll_up(self):
+        """Test that scroll('up') evaluates a negative vertical scrollBy."""
+        page = _page()
+        result = scroll(page, direction="up", pixels=200)
+        page.evaluate.assert_called_once_with("window.scrollBy(0, -200)")
+        assert result["scrolled"] == "up"
+
+    def test_scroll_right(self):
+        """Test that scroll('right') evaluates a horizontal-positive scrollBy."""
+        page = _page()
+        result = scroll(page, direction="right", pixels=100)
+        page.evaluate.assert_called_once_with("window.scrollBy(100, 0)")
+        assert result["scrolled"] == "right"
+
+    def test_scroll_left(self):
+        """Test that scroll('left') evaluates a horizontal-negative scrollBy."""
+        page = _page()
+        result = scroll(page, direction="left", pixels=100)
+        page.evaluate.assert_called_once_with("window.scrollBy(-100, 0)")
+        assert result["scrolled"] == "left"
+
+    def test_invalid_direction_returns_error(self):
+        """Test that an unrecognised direction returns an error dict without calling evaluate."""
+        page = _page()
+        result = scroll(page, direction="diagonal")
+        assert "error" in result
+        assert "diagonal" in result["error"]
+        page.evaluate.assert_not_called()
+
+    def test_default_pixels_is_500(self):
+        """Test that the default pixel amount is 500 when not specified."""
+        page = _page()
+        result = scroll(page)
+        assert result["pixels"] == 500
+
+
+class TestScrollToElement:
+    """Tests for the scroll_to_element() tool."""
+
+    def test_element_found(self):
+        """Test that scroll_to_element calls scroll_into_view_if_needed when element is found."""
+        page = _page()
+        el = MagicMock()
+        page.query_selector.return_value = el
+        result = scroll_to_element(page, "#target")
+        el.scroll_into_view_if_needed.assert_called_once()
+        assert result["found"] is True
+        assert result["selector"] == "#target"
+
+    def test_element_not_found(self):
+        """Test that scroll_to_element returns found=False when the selector matches nothing."""
+        page = _page()
+        page.query_selector.return_value = None
+        result = scroll_to_element(page, "#missing")
+        assert result["found"] is False
+        assert result["selector"] == "#missing"
+
+
+class TestScrollToBottom:
+    """Tests for the scroll_to_bottom() tool."""
+
+    def test_scroll_to_bottom_evaluates_js(self):
+        """Test that scroll_to_bottom calls page.evaluate with the scrollHeight expression."""
+        page = _page()
+        result = scroll_to_bottom(page)
+        page.evaluate.assert_called_once_with(
+            "window.scrollTo(0, document.body.scrollHeight)"
+        )
+        assert result["action"] == "scroll_to_bottom"
+
+
+class TestScrollToTop:
+    """Tests for the scroll_to_top() tool."""
+
+    def test_scroll_to_top_evaluates_js(self):
+        """Test that scroll_to_top calls page.evaluate with the scrollTo(0,0) expression."""
+        page = _page()
+        result = scroll_to_top(page)
+        page.evaluate.assert_called_once_with("window.scrollTo(0, 0)")
+        assert result["action"] == "scroll_to_top"

--- a/tests/test_tools_wait.py
+++ b/tests/test_tools_wait.py
@@ -1,0 +1,94 @@
+"""Tests for browser-agent wait tools: wait_for_element, wait_for_load, wait_for_url."""
+
+from unittest.mock import MagicMock
+
+from browsegenie.core.browser_agent.tools.wait import (
+    wait_for_element,
+    wait_for_load,
+    wait_for_url,
+)
+
+
+def _page(url="https://example.com"):
+    """Return a mock Playwright Page with preset url."""
+    page = MagicMock()
+    page.url = url
+    return page
+
+
+class TestWaitForElement:
+    """Tests for the wait_for_element() tool."""
+
+    def test_element_found(self):
+        """Test that wait_for_element returns found=True when selector appears."""
+        page = _page()
+        result = wait_for_element(page, "#submit")
+        assert result["found"] is True
+        assert result["selector"] == "#submit"
+        assert result["state"] == "visible"
+
+    def test_element_not_found_on_timeout(self):
+        """Test that wait_for_element returns found=False when wait times out."""
+        page = _page()
+        page.wait_for_selector.side_effect = Exception("timeout")
+        result = wait_for_element(page, "#missing")
+        assert result["found"] is False
+        assert result["selector"] == "#missing"
+
+    def test_custom_state_forwarded(self):
+        """Test that a custom state value is forwarded to page.wait_for_selector."""
+        page = _page()
+        wait_for_element(page, "button", state="attached", timeout=5000)
+        page.wait_for_selector.assert_called_once_with(
+            "button", state="attached", timeout=5000
+        )
+
+
+class TestWaitForLoad:
+    """Tests for the wait_for_load() tool."""
+
+    def test_loaded_success(self):
+        """Test that wait_for_load returns loaded=True on success."""
+        page = _page(url="https://loaded.com")
+        result = wait_for_load(page)
+        assert result["loaded"] is True
+        assert result["url"] == "https://loaded.com"
+
+    def test_loaded_failure(self):
+        """Test that wait_for_load returns loaded=False when the wait times out."""
+        page = _page()
+        page.wait_for_load_state.side_effect = Exception("timeout")
+        result = wait_for_load(page)
+        assert result["loaded"] is False
+
+    def test_default_state_is_domcontentloaded(self):
+        """Test that the default load state is domcontentloaded."""
+        page = _page()
+        wait_for_load(page)
+        page.wait_for_load_state.assert_called_once_with(
+            "domcontentloaded", timeout=10000
+        )
+
+
+class TestWaitForUrl:
+    """Tests for the wait_for_url() tool."""
+
+    def test_matched_success(self):
+        """Test that wait_for_url returns matched=True when the URL matches."""
+        page = _page(url="https://dashboard.com")
+        result = wait_for_url(page, "dashboard")
+        assert result["matched"] is True
+        assert result["url"] == "https://dashboard.com"
+
+    def test_matched_failure(self):
+        """Test that wait_for_url returns matched=False when the URL never matches."""
+        page = _page()
+        page.wait_for_url.side_effect = Exception("timeout")
+        result = wait_for_url(page, "never-appears")
+        assert result["matched"] is False
+
+    def test_url_pattern_forwarded(self):
+        """Test that the url_pattern argument is passed directly to page.wait_for_url."""
+        page = _page()
+        wait_for_url(page, "**/dashboard*", timeout=3000)
+        page.wait_for_url.assert_called_once_with("**/dashboard*", timeout=3000)

--- a/tests/test_web_ui_providers.py
+++ b/tests/test_web_ui_providers.py
@@ -1,0 +1,193 @@
+"""Tests for web UI providers: PROVIDERS dict, get_models(), and helper functions."""
+
+from unittest.mock import MagicMock, patch
+
+from browsegenie.core.web_ui.providers import (
+    PROVIDERS,
+    _is_chat_model,
+    _model_sort_key,
+    _models_from_litellm,
+    get_models,
+)
+
+
+class TestProvidersRegistry:
+    """Tests for the PROVIDERS constant."""
+
+    def test_providers_contains_google(self):
+        """Test that the google provider is registered in PROVIDERS."""
+        assert "google" in PROVIDERS
+
+    def test_providers_contains_openai(self):
+        """Test that the openai provider is registered in PROVIDERS."""
+        assert "openai" in PROVIDERS
+
+    def test_providers_contains_anthropic(self):
+        """Test that the anthropic provider is registered in PROVIDERS."""
+        assert "anthropic" in PROVIDERS
+
+    def test_providers_contains_ollama(self):
+        """Test that the ollama provider is registered in PROVIDERS."""
+        assert "ollama" in PROVIDERS
+
+    def test_each_provider_has_name_and_litellm_key(self):
+        """Test that every provider entry has both a name and a litellm_key field."""
+        for key, cfg in PROVIDERS.items():
+            assert "name" in cfg, f"Provider '{key}' missing 'name'"
+            assert "litellm_key" in cfg, f"Provider '{key}' missing 'litellm_key'"
+
+
+class TestIsChatModel:
+    """Tests for the _is_chat_model() filter."""
+
+    def test_gpt4o_is_chat_model(self):
+        """Test that gpt-4o is identified as a chat model."""
+        assert _is_chat_model("gpt-4o") is True
+
+    def test_gemini_flash_is_chat_model(self):
+        """Test that gemini-2.5-flash is identified as a chat model."""
+        assert _is_chat_model("gemini-2.5-flash") is True
+
+    def test_claude_haiku_is_chat_model(self):
+        """Test that claude-3-haiku is identified as a chat model."""
+        assert _is_chat_model("claude-3-haiku-20240307") is True
+
+    def test_embedding_model_excluded(self):
+        """Test that embedding models are not considered chat models."""
+        assert _is_chat_model("text-embedding-ada-002") is False
+
+    def test_dalle_excluded(self):
+        """Test that DALL-E image generation models are excluded."""
+        assert _is_chat_model("dall-e-3") is False
+
+    def test_tts_excluded(self):
+        """Test that text-to-speech models are excluded."""
+        assert _is_chat_model("tts-1") is False
+
+    def test_whisper_excluded(self):
+        """Test that Whisper transcription models are excluded."""
+        assert _is_chat_model("whisper-1") is False
+
+
+class TestModelSortKey:
+    """Tests for the _model_sort_key() sort helper."""
+
+    def test_known_model_returns_tier_zero(self):
+        """Test that a recognised model name gets tier 0 (known release order)."""
+        key = _model_sort_key("gemini-2.5-flash")
+        assert key[0] == 0
+
+    def test_unknown_model_returns_tier_one(self):
+        """Test that an unrecognised model name gets tier 1 (alphabetical fallback)."""
+        key = _model_sort_key("completely-unknown-model-xyz")
+        assert key[0] == 1
+
+    def test_newer_model_sorts_before_older(self):
+        """Test that a newer model has a lower sort key than an older model."""
+        new_key = _model_sort_key("gemini-2.5-flash")
+        old_key = _model_sort_key("gemini-1.0-pro")
+        assert new_key < old_key
+
+    def test_litellm_prefixed_name_resolved(self):
+        """Test that litellm-prefixed names like 'gemini/gemini-2.0-flash' are resolved correctly."""
+        key = _model_sort_key("gemini/gemini-2.0-flash")
+        assert key[0] == 0
+
+
+class TestModelsFromLitellm:
+    """Tests for the _models_from_litellm() static fallback."""
+
+    def test_returns_list(self):
+        """Test that _models_from_litellm returns a list for a known provider key."""
+        import litellm
+        original = litellm.models_by_provider
+        try:
+            litellm.models_by_provider = {
+                "openai": {"gpt-4o", "gpt-3.5-turbo", "dall-e-3"}
+            }
+            result = _models_from_litellm("openai")
+        finally:
+            litellm.models_by_provider = original
+        assert isinstance(result, list)
+        assert "dall-e-3" not in result
+
+    def test_returns_empty_list_on_exception(self):
+        """Test that _models_from_litellm returns an empty list if an exception is raised."""
+        import litellm
+
+        class _Explode:
+            def get(self, key, default):
+                raise RuntimeError("boom")
+
+        original = litellm.models_by_provider
+        try:
+            litellm.models_by_provider = _Explode()
+            result = _models_from_litellm("openai")
+        finally:
+            litellm.models_by_provider = original
+        assert result == []
+
+
+class TestGetModels:
+    """Tests for the public get_models() function."""
+
+    def test_returns_dict_with_models_key(self):
+        """Test that get_models returns a dict with a 'models' key."""
+        with patch("browsegenie.core.web_ui.providers._models_from_litellm", return_value=["gpt-4o"]):
+            result = get_models("openai")
+        assert "models" in result
+        assert isinstance(result["models"], list)
+
+    def test_live_fetch_used_when_api_key_provided(self):
+        """Test that the live fetcher is called when an api_key is supplied for a supported provider."""
+        import browsegenie.core.web_ui.providers as prov_mod
+        mock_live = MagicMock(return_value=["gpt-4o-mini"])
+        original = prov_mod._LIVE_FETCHERS.get("openai")
+        try:
+            prov_mod._LIVE_FETCHERS["openai"] = mock_live
+            result = get_models("openai", api_key="sk-test")
+        finally:
+            prov_mod._LIVE_FETCHERS["openai"] = original
+        mock_live.assert_called_once_with("sk-test")
+        assert "gpt-4o-mini" in result["models"]
+
+    def test_litellm_fallback_when_no_api_key(self):
+        """Test that the litellm static registry is used when no api_key is supplied."""
+        with patch(
+            "browsegenie.core.web_ui.providers._models_from_litellm",
+            return_value=["gpt-4o"],
+        ) as mock_static:
+            get_models("openai")
+        mock_static.assert_called()
+
+    def test_litellm_fallback_when_live_fetch_empty(self):
+        """Test that the litellm fallback is used when the live fetch returns an empty list."""
+        with patch(
+            "browsegenie.core.web_ui.providers._models_live_openai",
+            return_value=[],
+        ), patch(
+            "browsegenie.core.web_ui.providers._models_from_litellm",
+            return_value=["gpt-4o"],
+        ) as mock_static:
+            result = get_models("openai", api_key="sk-key")
+        mock_static.assert_called()
+        assert "gpt-4o" in result["models"]
+
+    def test_ollama_uses_live_fetcher(self):
+        """Test that ollama always calls the live fetcher regardless of api_key."""
+        with patch(
+            "browsegenie.core.web_ui.providers._models_live_ollama",
+            return_value=["llama3"],
+        ) as mock_ollama:
+            result = get_models("ollama")
+        mock_ollama.assert_called()
+        assert "llama3" in result["models"]
+
+    def test_unknown_provider_returns_litellm_fallback(self):
+        """Test that an unregistered provider falls back to the litellm static registry."""
+        with patch(
+            "browsegenie.core.web_ui.providers._models_from_litellm",
+            return_value=[],
+        ):
+            result = get_models("unknown_provider")
+        assert "models" in result


### PR DESCRIPTION
## Summary

Adds 192 unit tests across 14 new test files, covering modules that had little or no test coverage. All tests use mocks — no network calls, no real browser, no real LLM API.

### New test files

| File | Module covered | Key scenarios |
|---|---|---|
| `test_tools_navigation.py` | `tools/navigation.py` | `navigate`, `go_back`, `go_forward`, `reload`; networkidle timeout swallowed |
| `test_tools_scroll.py` | `tools/scroll.py` | All four scroll directions, invalid direction → error, `scroll_to_element` hit/miss, `scroll_to_bottom/top` |
| `test_tools_wait.py` | `tools/wait.py` | `wait_for_element`, `wait_for_load`, `wait_for_url` success and timeout paths |
| `test_tools_interaction.py` | `tools/interaction.py` | `click` by selector/index/coordinates, index out-of-range, JS fallback; `fill` with clear/no-clear; `press_key`, `hover`, `select_option` by value and label, `drag_and_drop` |
| `test_tools_extraction.py` | `tools/extraction.py` | `get_page_content` with body None and inner_text exception; `find_elements` happy path and JS exception; `get_interactive_elements`; `execute_js` result truncation |
| `test_llm_client.py` | `agent/llm.py` | `_normalize_model` for all six provider prefixes; `LLMClient.complete` with and without api_key; `complete_text`; token accumulation; None tokens not appended |
| `test_prompts.py` | `agent/prompts.py` | `SYSTEM_PROMPT` contains all `KNOWN_TARGETS`; `capture_page_state` happy path; text capped at 1500 chars; exception falls back to `current_url()` |
| `test_browser_session_module.py` | `agent/sessions.py` | `BrowserAgentSession.start/stop`, `is_done` after success and after exception, control delegation methods, module-level session registry |
| `test_mcp_tools.py` | `mcp/tools.py` | All five tool classes — happy path, validation error, generic exception; `ToolManager` dispatch including unknown tool name |
| `test_mcp_server.py` | `mcp/server.py` | Lazy scraper creation and memoisation, `_handle_list_tools` success and exception, `_handle_call_tool` delegation and exception path |
| `test_browse_function.py` | `browser.py` | `_resolve_model_and_provider` for all model-name prefixes; `browse()` happy path, `on_event` callback, timeout → `session.stop()`, error event |
| `test_web_ui_providers.py` | `web_ui/providers.py` | `PROVIDERS` registry shape; `_is_chat_model` include/exclude patterns; `_model_sort_key`; `get_models` with live-fetch, litellm fallback, empty live result, ollama |
| `test_html_fetcher_extra.py` | `html_fetcher.py` | SPA-detected path, short-content fallback, cloudscraper-None fallback, both-fail → raises; Selenium `TimeoutException` and `WebDriverException` |
| `test_shims.py` | `mcp_server.py`, `web_ui.py` | `main_sync` delegation, `main` is a coroutine, re-exports importable from web_ui shim |

## Test plan

- [x] 547 total tests, 0 failures
- [x] `flake8 --select=E9,F63,F7,F82` — 0 errors on all new files